### PR TITLE
otasigcheck: Avoid long lines in XML

### DIFF
--- a/prebuilt/common/bin/otasigcheck.sh
+++ b/prebuilt/common/bin/otasigcheck.sh
@@ -20,6 +20,9 @@ if [ -f "/data/system/packages.xml" -a -f "/tmp/releasekey" ]; then
   OLDIFS="$IFS"
   IFS=""
   while read line; do
+    if [ "${#line}" -gt 4094 ]; then
+      continue
+    fi
     params=${line# *<package *}
     if [ "$line" != "$params" ]; then
       kvp=${params%% *}


### PR DESCRIPTION
Shells based on busybox, such as found in CM 12.1 recovery and TWRP, do not
properly handle pattern based parameter expansion for variables longer than
4kb.  This throws our naive little XML parser into an infinite loop.  Since
all such lines are associated with external app certs, just skip them.

Change-Id: I203b65c1ffd62bf3261b3ae315327314a5006952
